### PR TITLE
Fixed URL handling error when tracking time on tabs.

### DIFF
--- a/pro-tasker/src/background/index.ts
+++ b/pro-tasker/src/background/index.ts
@@ -4,6 +4,8 @@ export {}
 console.log("background")
 var domain = "inactive"
 var day = new Date().getDay().toString()
+// activeTabId needed for the onUpdated listener
+var activeTabId = null; 
 const hour = new Date().getHours()
 const min = new Date().getMinutes()
 chrome.alarms.create("taskTimer", {
@@ -19,7 +21,7 @@ chrome.runtime.onInstalled.addListener(async function (details) {
   if (details.reason === "install" || details.reason === "update") {
     // Initialize data for numbers 1-7 in Chrome's local storage
     const initialData = {}
-    for (let i = 0; i <= parseInt(day); i++) {
+    for (let i = 0; i <= 6; i++) {
       console.log(i)
       if (
         Object.keys(await chrome.storage.local.get([i.toString()])).length == 0
@@ -68,48 +70,48 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   }
 })
 
-//set current website to local storage to initialize into DB
-chrome.tabs.onActivated.addListener(function (activeInfo) {
-  chrome.tabs.get(activeInfo.tabId, function (tab) {
-    domain = new URL(tab.url).hostname
-    if (domain.includes(".")) {
-      day = new Date().getDay().toString()
-      chrome.storage.local.get(day, (result) => {
-        // Check if the entire day does not have an entry
-        if (typeof result[day] === "undefined") {
-          chrome.storage.local.set({ [day]: { [domain]: 0 } })
-        }
-        // Check if the website domain has not been entered.
-        else if (typeof result[day][domain] === "undefined") {
-          chrome.storage.local.set({ [day]: { ...result[day], [domain]: 0 } })
-        }
-      })
-    } else {
-      domain = "inactive"
-    }
-  })
-})
+// Function to handle URL extraction and storage
+function handleTab(tab) {
+  if (tab && tab.url) {
+      var tabUrl;
+      try {
+          tabUrl = new URL(tab.url).hostname;
+      } catch (error) {
+          // Handle invalid URLs or URLs not fully loaded
+          tabUrl = "invalid";
+      }
+      if (tabUrl !== "invalid") {
+          domain = tabUrl;
+          if (domain.includes(".")) {
+              day = new Date().getDay().toString();
+              chrome.storage.local.get(day, (result) => {
+                  if (typeof result[day] === "undefined") {
+                      chrome.storage.local.set({ [day]: { [domain]: 0 } });
+                  } else if (typeof result[day][domain] === "undefined") {
+                      chrome.storage.local.set({ [day]: { ...result[day], [domain]: 0 } });
+                  }
+              });
+          } else {
+              domain = "inactive";
+          }
+      }
+  }
+}
 
-chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-  chrome.tabs.get(tabId, function (tab) {
-    domain = new URL(tab.url).hostname
-    if (domain.includes(".")) {
-      day = new Date().getDay().toString()
-      chrome.storage.local.get(day, (result) => {
-        // Check if the entire day does not have an entry
-        if (typeof result[day] === "undefined") {
-          chrome.storage.local.set({ [day]: { [domain]: 0 } })
-        }
-        // Check if the website domain has not been entered.
-        else if (typeof result[day][domain] === "undefined") {
-          chrome.storage.local.set({ [day]: { ...result[day], [domain]: 0 } })
-        }
-      })
-    } else {
-      domain = "inactive"
-    }
-  })
-})
+// Handle tab activation
+chrome.tabs.onActivated.addListener(function(activeInfo) {
+  activeTabId = activeInfo.tabId; // Update active tab ID
+  chrome.tabs.get(activeTabId, function(tab) {
+      handleTab(tab);
+  });
+});
+
+// Handle tab updates
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+  if (tabId === activeTabId && changeInfo.status === 'complete') { // Check if the updated tab is the active tab
+      handleTab(tab);
+  }
+});
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === "mostUsedTimer") {


### PR DESCRIPTION
Previously, if a tab was not completely loaded it would throw "TypeError: Failed to construct 'URL': Invalid URL". Fixed by adding a onUpdated listener to check again when the tab completes loading.